### PR TITLE
Stick to python3.8 in order run properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Using python3.8 allows deployment without issues in 2026. :)